### PR TITLE
Change BlockType from struct to class

### DIFF
--- a/src/Resource/BlockType.hpp
+++ b/src/Resource/BlockType.hpp
@@ -40,7 +40,7 @@ namespace Resource {
 #define BLOCK_SPRUCE	(1u << 4)
 #define BLOCK_WATER	(1u << 5)
 
-struct BlockType {
+class BlockType {
 private:
 	static const std::unordered_map<std::string, BlockType> Types;
 


### PR DESCRIPTION
Fixes the -Wmismatched-tags compilation warning.