### PR TITLE
Enable building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,21 @@ cmake_minimum_required(VERSION 2.8.12)
 project(MINEDMAP CXX)
 
 
-find_package(PNG REQUIRED)
+# search for pkg-config
+include (FindPkgConfig)
+if (NOT PKG_CONFIG_FOUND)
+    message (FATAL_ERROR "pkg-config not found")
+endif ()
+
+# check for libpng
+pkg_check_modules (LIBPNG libpng16 REQUIRED)
+if (NOT LIBPNG_FOUND)
+    message(FATAL_ERROR "You don't seem to have libpng16 development libraries installed")
+else ()
+    include_directories (${LIBPNG_INCLUDE_DIRS})
+    link_directories (${LIBPNG_LIBRARY_DIRS})
+    link_libraries (${LIBPNG_LIBRARIES})
+endif ()
 find_package(ZLIB REQUIRED)
 
 

--- a/src/MinedMap.cpp
+++ b/src/MinedMap.cpp
@@ -206,8 +206,10 @@ static int64_t getModTime(const std::string &file) {
 		return INT64_MIN;
 	}
 
-#ifdef _WIN32
+#if defined(_WIN32)
 	return (int64_t)s.st_mtime * 1000000;
+#elif defined(__APPLE__) || defined(__NetBSD__)
+	return (int64_t)s.st_mtimespec.tv_sec * 1000000 + s.st_mtimespec.tv_nsec / 1000;
 #else
 	return (int64_t)s.st_mtim.tv_sec * 1000000 + s.st_mtim.tv_nsec / 1000;
 #endif


### PR DESCRIPTION
### Issues compiling on macOS

- The time value in `stat` is called `st_mtimespec` on macOS and BSD
- macOS bundles an old version of *libpng* which all macOS users have by default, but developers often have [Homebrew](https://brew.sh/)'s version installed in parallel, which doesn't get found properly with `find_package(PNG REQUIRED)`

### Fixes

#### `st_mtimespec`

- Add another preprocessor directive to use `st_mtimespec` on Apple and BSD systems.

*note:* Should the list of systems using different names for time in `stat` grow longer, it might be a better idea to move this stack of directives to a separate file.

#### libpng

- Find the correct version of *libpng* using [this *pkg-config* method described on Stack Overflow](https://stackoverflow.com/a/30981965)

*note:* ⚠️ This will cause issues on systems that do not have *pkg-config* installed. This may be a part of *build-essential*, but if not, then either it should be added as a requirement, or a different way to find the correct *libpng* should be considered.