### PR TITLE
Quality of life updates to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
 /viewer/data
+/resource/data
+/resource/colors.json
 .idea/
 cmake-build-debug/


### PR DESCRIPTION
This PR adds a few entries to the gitignore file that are commonly used / mentioned in the repo's documentation.

--------

The documentation around updating MinedMap to support new blocks mentions extracting the minecraft .jar file to `/resource/data`, and the `extract.py` creates a `colors.json` file that is not needed for build, but it's temporarily used to add entries to the source code.

So I added those two entries to the gitignore file to prevent those files form being accidentally added to the repo