### PR TITLE
Update to compile on Mac OS

### DIFF
--- a/src/MinedMap.cpp
+++ b/src/MinedMap.cpp
@@ -196,7 +196,7 @@ static int64_t getModTime(const std::string &file) {
 	return (int64_t)s.st_mtime * 1000000;
 #else
     #ifdef __APPLE__
-        // stat.h syntax has changed on MacOSX SDK since at least 11.3
+        // stat.h syntax has changed on MacOSX SDK since at least 10.15
         return (int64_t)s.st_mtimespec.tv_sec * 1000000 + s.st_mtimespec.tv_nsec / 1000;
     #else
         return (int64_t)s.st_mtim.tv_sec * 1000000 + s.st_mtim.tv_nsec / 1000;

--- a/src/MinedMap.cpp
+++ b/src/MinedMap.cpp
@@ -195,7 +195,12 @@ static int64_t getModTime(const std::string &file) {
 #ifdef _WIN32
 	return (int64_t)s.st_mtime * 1000000;
 #else
-	return (int64_t)s.st_mtim.tv_sec * 1000000 + s.st_mtim.tv_nsec / 1000;
+    #ifdef __APPLE__
+        // stat.h syntax has changed on MacOSX SDK since at least 11.3
+        return (int64_t)s.st_mtimespec.tv_sec * 1000000 + s.st_mtimespec.tv_nsec / 1000;
+    #else
+        return (int64_t)s.st_mtim.tv_sec * 1000000 + s.st_mtim.tv_nsec / 1000;
+    #endif
 #endif
 }
 


### PR DESCRIPTION
I ran into an issue compiling the software on my M1 Mac, though I'm not sure if the issue is really the new processor architecture. Looking back at the Mac OSX command line tools SDK, the `stat.h` header has defined different behavior since at least version 10.15 (macOS Mojave 10.14.4, which is quite a few years back now).

## Error

Here's the error I got when running the `make` command:
```bash
MinedMap/src/MinedMap.cpp:198:20 error: no member named 'st_mtim' in 'stat'
```

I had a look at the stat.h and it looks like `st_mtim` has been replaced by `st_mtimespec`

## Solution

I added another level of the `#ifdef` conditional tree to check for the `__APPLE__` macro. If it is defined, the `st_mtimespec` syntax is used. Otherwise the `st_mtim` syntax is used

## Testing

I successfully compiled the code on:
* Ubuntu 12.0.4.4 LTS
* M1 Mac (OS 12.3, command line tools version 12.3.0.0.0.1.1627064638)
* Intel Mac (OS 11.6.7, command line tools version 13.2..0.0.1.1638488800)

It runs fine on all three systems. I'm not sure how far back the `stat.h` syntax diverged on the Mac OSX SDK, so this update may not be completely backwards compatible with older Mac OS versions