### PR TITLE
core: update region and lightmap version

### DIFF
--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// Increase when the generation of processed regions from region data changes
 /// (usually because of updated resource data)
-pub const REGION_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(7);
+pub const REGION_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(8);
 
 /// MinedMap map tile data version number
 ///
@@ -38,7 +38,7 @@ pub const MAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(0);
 ///
 /// Increase when the generation of lightmap tiles from region data changes
 /// (usually because of updated resource data)
-pub const LIGHTMAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(5);
+pub const LIGHTMAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(6);
 
 /// MinedMap mipmap data version number
 ///


### PR DESCRIPTION
The versions need to be updated for the new block type.