### PR TITLE
resource: add `mob_spawner` alias for `spawner` block

### DIFF
--- a/crates/resource/src/block_types.rs
+++ b/crates/resource/src/block_types.rs
@@ -6039,6 +6039,16 @@ pub const BLOCK_TYPES: &[(&str, ConstBlockType)] = &[
 		},
 	),
 	(
+		"mob_spawner",
+		ConstBlockType {
+			block_color: BlockColor {
+				flags: make_bitflags!(BlockFlag::{Opaque}),
+				color: Color([36, 46, 62]),
+			},
+			sign_material: None,
+		},
+	),
+	(
 		"moss_block",
 		ConstBlockType {
 			block_color: BlockColor {

--- a/resource/blocks.json
+++ b/resource/blocks.json
@@ -1191,6 +1191,9 @@
 	"melon_stem": {
 		"grass": true
 	},
+	"mob_spawner": {
+		"texture": "spawner"
+	},
 	"moss_block": {},
 	"moss_carpet": {
 		"texture": "moss_block"

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// Increase when the generation of processed regions from region data changes
 /// (usually because of updated resource data)
-pub const REGION_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(11);
+pub const REGION_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(12);
 
 /// MinedMap map tile data version number
 ///
@@ -37,7 +37,7 @@ pub const MAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(0);
 ///
 /// Increase when the generation of lightmap tiles from region data changes
 /// (usually because of updated resource data)
-pub const LIGHTMAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(8);
+pub const LIGHTMAP_FILE_META_VERSION: FileMetaVersion = FileMetaVersion(9);
 
 /// MinedMap mipmap data version number
 ///


### PR DESCRIPTION
While the block is called `spawner` in current Minecraft versions, upgrading pre-flattening worlds can still result in the `mob_spawner` ID being used. It is unclear whether this is a bug in Minecraft, but is is easy to support for MinedMap.